### PR TITLE
Metadata

### DIFF
--- a/source/flod/adapter.d
+++ b/source/flod/adapter.d
@@ -11,8 +11,8 @@ import flod.traits;
 
 private template DefaultPullPeekAdapter(Buffer, E) {
 	@pullSink!E @peekSource!E
-	struct DefaultPullPeekAdapter(Source) {
-		Source source;
+	struct DefaultPullPeekAdapter(alias Context, A...) {
+		mixin Context!A;
 		Buffer buffer;
 
 		this()(auto ref Buffer buffer)
@@ -55,8 +55,8 @@ auto pullPeek(Pipeline)(auto ref Pipeline pipeline)
 
 private template DefaultPeekPullAdapter(E) {
 	@peekSink!E @pullSource!E
-	struct DefaultPeekPullAdapter(Source) {
-		Source source;
+	struct DefaultPeekPullAdapter(alias Context, A...) {
+		mixin Context!A;
 
 		size_t pull(E[] buf)
 		{
@@ -79,9 +79,8 @@ auto peekPull(Pipeline)(auto ref Pipeline pipeline)
 
 private template DefaultPullPushAdapter(E) {
 	@pullSink!E @pushSource!E
-	struct DefaultPullPushAdapter(Source, Sink) {
-		Source source;
-		Sink sink;
+	struct DefaultPullPushAdapter(alias Context, A...) {
+		mixin Context!A;
 		size_t chunkSize;
 
 		this(size_t chunkSize)
@@ -113,9 +112,8 @@ auto pullPush(Pipeline)(auto ref Pipeline pipeline, size_t chunkSize = 4096)
 
 private template DefaultPullAllocAdapter(E) {
 	@pullSink!E @allocSource!E
-	struct DefaultPullAllocAdapter(Source, Sink) {
-		Source source;
-		Sink sink;
+	struct DefaultPullAllocAdapter(alias Context, A...) {
+		mixin Context!A;
 		size_t chunkSize;
 
 		this(size_t chunkSize)
@@ -150,9 +148,8 @@ auto pullAlloc(Pipeline)(auto ref Pipeline pipeline, size_t chunkSize = 4096)
 
 private template DefaultPeekPushAdapter(E) {
 	@peekSink!E @pushSource!E
-	struct DefaultPeekPushAdapter(Source, Sink) {
-		Source source;
-		Sink sink;
+	struct DefaultPeekPushAdapter(alias Context, A...) {
+		mixin Context!A;
 		size_t minSliceSize;
 
 		this(size_t minSliceSize)
@@ -185,9 +182,8 @@ auto peekPush(Pipeline)(auto ref Pipeline pipeline, size_t minSliceSize = size_t
 
 private template DefaultPeekAllocAdapter(E) {
 	@peekSink!E @allocSource!E
-	struct DefaultPeekAllocAdapter(Source, Sink) {
-		Source source;
-		Sink sink;
+	struct DefaultPeekAllocAdapter(alias Context, A...) {
+		mixin Context!A;
 		size_t minSliceSize;
 		size_t maxSliceSize;
 
@@ -228,8 +224,8 @@ auto peekAlloc(Pipeline)(auto ref Pipeline pipeline, size_t minSliceSize = size_
 
 private template DefaultPushAllocAdapter(E) {
 	@pushSink!E @allocSource!E
-	struct DefaultPushAllocAdapter(Sink) {
-		Sink sink;
+	struct DefaultPushAllocAdapter(alias Context, A...) {
+		mixin Context!A;
 
 		size_t push(const(E)[] buf)
 		{
@@ -255,10 +251,9 @@ auto pushAlloc(Pipeline)(auto ref Pipeline pipeline)
 
 private template DefaultPushPullAdapter(Buffer, E) {
 	@pushSink!E @pullSource!E
-	struct DefaultPushPullAdapter(alias Scheduler) {
+	struct DefaultPushPullAdapter(alias Context, A...) {
 		import std.algorithm : min;
-
-		mixin Scheduler;
+		mixin Context!A;
 
 		Buffer buffer;
 		const(E)[] pushed;
@@ -381,9 +376,9 @@ private template ImplementAllocCommit(E) {
 
 private template DefaultPushPeekAdapter(Buffer, E) {
 	@pushSink!E @peekSource!E
-	struct DefaultPushPeekAdapter(alias Scheduler) {
+	struct DefaultPushPeekAdapter(alias Context, A...) {
 		import std.algorithm : min;
-		mixin Scheduler;
+		mixin Context!A;
 		Buffer buffer;
 
 		this()(auto ref Buffer buffer)
@@ -428,9 +423,9 @@ auto pushPeek(Pipeline)(auto ref Pipeline pipeline)
 
 private template DefaultAllocPeekAdapter(Buffer, E) {
 	@allocSink!E @peekSource!E
-	struct DefaultAllocPeekAdapter(alias Scheduler) {
+	struct DefaultAllocPeekAdapter(alias Context, A...) {
 		import std.algorithm : min;
-		mixin Scheduler;
+		mixin Context!A;
 		Buffer buffer;
 
 		this()(auto ref Buffer buffer)
@@ -462,9 +457,9 @@ auto allocPeek(Pipeline)(auto ref Pipeline pipeline)
 
 private template DefaultAllocPullAdapter(Buffer, E) {
 	@allocSink!E @pullSource!E
-	struct DefaultAllocPullAdapter(alias Scheduler) {
+	struct DefaultAllocPullAdapter(alias Context, A...) {
 		import std.algorithm : min;
-		mixin Scheduler;
+		mixin Context!A;
 		Buffer buffer;
 
 		this()(auto ref Buffer buffer)
@@ -511,8 +506,8 @@ auto allocPull(Pipeline)(auto ref Pipeline pipeline)
 
 private template DefaultAllocPushAdapter(Buffer, E) {
 	@allocSink!E @pushSource!E
-	struct DefaultAllocPushAdapter(Sink) {
-		Sink sink;
+	struct DefaultAllocPushAdapter(alias Context, A...) {
+		mixin Context!A;
 		Buffer buffer;
 
 		this()(auto ref Buffer buffer)

--- a/source/flod/meta.d
+++ b/source/flod/meta.d
@@ -59,14 +59,6 @@ template str(W...) {
 }
 
 ///
-template repeat(int id, string s) {
-	static if (id == 0)
-		enum repeat = "";
-	else
-		enum repeat = s ~ repeat!(id - 1, s);
-}
-
-///
 template ReplaceWithMask(ulong mask, ReplacementForZeros, Types...) {
 	alias What = ReplacementForZeros;
 	import std.meta : AliasSeq;

--- a/source/flod/meta.d
+++ b/source/flod/meta.d
@@ -112,3 +112,11 @@ auto moveIfNonCopyable(T, string file = __FILE__, int line = __LINE__)(auto ref 
 		return move(t);
 	}
 }
+
+template tupleFromArray(T, T[] arr) {
+	import std.meta : AliasSeq;
+	static if (arr.length)
+		alias tupleFromArray = AliasSeq!(arr[0], tupleFromArray!(T, arr[1 .. $]));
+	else
+		alias tupleFromArray = AliasSeq!();
+}

--- a/source/flod/metadata.d
+++ b/source/flod/metadata.d
@@ -7,14 +7,14 @@
 module flod.metadata;
 
 import std.algorithm : isSorted;
-import std.meta : Filter;
-import std.typecons : tuple;
+import std.meta : AliasSeq, Filter, allSatisfy, anySatisfy, staticMap;
+import std.typecons : Tuple, tuple;
 
 import flod.traits;
 
 package enum TagOp { get, set }
 
-package struct TagSpec(T, string k, TagOp o) {
+package struct TagAttribute(T, string k, TagOp o) {
 	alias Type = T;
 	enum string key = k;
 	enum TagOp op = o;
@@ -22,11 +22,17 @@ package struct TagSpec(T, string k, TagOp o) {
 
 enum tagSetter() = tuple().expand;
 enum tagGetter() = tuple().expand;
-enum tagSetter(T, string k, Z...) = tuple(TagSpec!(T, k, TagOp.set)(), tagSetter!Z).expand;
-enum tagGetter(T, string k, Z...) = tuple(TagSpec!(T, k, TagOp.get)(), tagGetter!Z).expand;
+enum tagSetter(T, string k, Z...) = tuple(TagAttribute!(T, k, TagOp.set)(), tagSetter!Z).expand;
+enum tagGetter(T, string k, Z...) = tuple(TagAttribute!(T, k, TagOp.get)(), tagGetter!Z).expand;
 
-private enum isTagSpec(S...) = is(typeof(S[0]) : TagSpec!_a, _a...);
-package enum getTagSpecs(alias S) = Filter!(isTagSpec, __traits(getAttributes, S));
+private enum isTagAttribute(S...) = is(typeof(S[0]) : TagAttribute!_a, _a...);
+package enum getTagAttributes(S...) = tuple(Filter!(isTagAttribute, __traits(getAttributes, S[0]))).expand;
+
+unittest {
+	static struct Bar {}
+	enum x = getTagAttributes!Bar;
+	static assert(x.length == 0);
+}
 
 unittest {
 	@tagSetter!(uint, "foo")
@@ -34,18 +40,161 @@ unittest {
 	@tagGetter!(double, "baz", string, "quux")
 	@pushSink!uint
 	static struct Foo {}
-	enum x = getTagSpecs!Foo;
+	enum x = getTagAttributes!Foo;
 	static assert(x.length == 4);
-	static assert(x[0] == TagSpec!(uint, "foo", TagOp.set)());
-	static assert(x[1] == TagSpec!(string, "bar", TagOp.set)());
-	static assert(x[2] == TagSpec!(double, "baz", TagOp.get)());
-	static assert(x[3] == TagSpec!(string, "quux", TagOp.get)());
+	static assert(x[0] == TagAttribute!(uint, "foo", TagOp.set)());
+	static assert(x[1] == TagAttribute!(string, "bar", TagOp.set)());
+	static assert(x[2] == TagAttribute!(double, "baz", TagOp.get)());
+	static assert(x[3] == TagAttribute!(string, "quux", TagOp.get)());
 }
 
-private struct Tag(T, string key, size_t[] setters)
-	if (isSorted(setters))
+/// Bundles stage index and its TagAttributes
+private template TagAttributeTuple(size_t i, ta...)
+	if (allSatisfy!(isTagAttribute, ta))
 {
-	enum size_t length = setters.length;
+	enum size_t index = i;
+	enum tagAttributes = tuple(ta).expand;
+
+	static if (tagAttributes.length) {
+		enum front = tagAttributes[0];
+		alias removeFront = TagAttributeTuple!(index, tagAttributes[1 .. $]);
+	} else {
+		alias removeFront = TagAttributeTuple!(index);
+	}
+}
+
+/** Extracts tag attributes from a sequence of stages.
+Params:
+i = index of first stage in StageSeq
+StageSeq = sequence of stages
+*/
+template FilterTagAttributes(size_t i, StageSeq...)
+	if (allSatisfy!(isStage, StageSeq))
+{
+	static if (StageSeq.length) {
+		alias tags = getTagAttributes!(StageSeq[0]);
+		static if (tags.length)
+			alias FilterTagAttributes = AliasSeq!(TagAttributeTuple!(i, getTagAttributes!(StageSeq[0])),
+				.FilterTagAttributes!(i + 1, StageSeq[1 .. $]));
+		else
+			alias FilterTagAttributes = .FilterTagAttributes!(i + 1, StageSeq[1 .. $]);
+	} else {
+		alias FilterTagAttributes = AliasSeq!();
+	}
+}
+
+/// Bundles tag value type, key, and indexes of all setters
+private template TagSpec(T, string k, size_t[] s)
+	if (isSorted(s))
+{
+	alias Type = T;
+	enum string key = k;
+	enum setters = s;
+}
+
+private enum isTagSpec(S...) = is(S[0].Type)
+	&& is(typeof(S[0].key) == string) && is(typeof(S[0].setters) == size_t[]);
+
+unittest {
+	static assert( isTagSpec!(TagSpec!(double, "foo", [ 1, 4, 5 ])));
+	static assert(!isTagSpec!());
+	static assert(!isTagSpec!2);
+	static assert(!isTagSpec!(Id!int));
+}
+
+template hasKey(string k) {
+	enum bool hasKey(alias S) = S.key == k;
+}
+
+template TagSpecByKey(string k, tagSpecs...)
+	if (allSatisfy!(isTagSpec, tagSpecs))
+{
+	alias TagSpecByKey = Filter!(hasKey!k, tagSpecs);
+}
+
+unittest {
+	alias specs = AliasSeq!(
+		TagSpec!(uint, "foo", [ 1, 2, 15 ]),
+		TagSpec!(uint, "bar", [ 5 ]),
+		TagSpec!(uint, "baz", [ 7, 42 ]));
+	alias bar = TagSpecByKey!("bar", specs);
+	static assert(is(Id!bar == Id!(specs[1])));
+}
+
+template RemoveTagSpecByKey(string k, tagSpecs...)
+	if (allSatisfy!(isTagSpec, tagSpecs))
+{
+	static if (tagSpecs.length == 0)
+		alias RemoveTagSpecByKey = AliasSeq!();
+	else static if (tagSpecs[0].key == k)
+		alias RemoveTagSpecByKey = RemoveTagSpecByKey!(k, tagSpecs[1 .. $]);
+	else
+		alias RemoveTagSpecByKey = AliasSeq!(tagSpecs[0], RemoveTagSpecByKey!(k, tagSpecs[1 .. $]));
+}
+
+unittest {
+	alias specs = AliasSeq!(
+		TagSpec!(uint, "foo", [ 1, 2, 15 ]),
+		TagSpec!(uint, "bar", [ 5 ]),
+		TagSpec!(uint, "baz", [ 7, 42 ]));
+	alias nobar = RemoveTagSpecByKey!("bar", specs);
+	static assert(is(Id!nobar == Id!(specs[0], specs[2])));
+}
+
+template MergeTagSpecs(alias NewSpec, tagSpecs...)
+	if (allSatisfy!(isTagSpec, NewSpec, tagSpecs))
+{
+	alias MergeTagSpecs = AliasSeq!(NewSpec, RemoveTagSpecByKey!(NewSpec.key, tagSpecs));
+}
+
+/** Transposes a sequence of (index, tag_attributes...) tuples into a sequence of TagSpecs
+*/
+template TagSpecSeq(TagAttributeTupleSeq...) {
+	static if (TagAttributeTupleSeq.length == 0)
+		alias TagSpecSeq = AliasSeq!();
+	else static if (TagAttributeTupleSeq[0].tagAttributes.length == 0)
+		alias TagSpecSeq = .TagSpecSeq!(TagAttributeTupleSeq[1 .. $]);
+	else {
+		alias AttrTuple = TagAttributeTupleSeq[0];
+		enum index = AttrTuple.index;
+		alias Type = AttrTuple.front.Type;
+		enum key = AttrTuple.front.key;
+		enum op = AttrTuple.front.op;
+		alias Tail = .TagSpecSeq!(AliasSeq!(AttrTuple.removeFront, TagAttributeTupleSeq[1 .. $]));
+		alias Spec = TagSpecByKey!(key, Tail);
+
+		static assert(allSatisfy!(isTagSpec, Spec, Tail));
+		static assert(Spec.length == 0 || is(Spec[0].Type == Type), "Conflicting types for tag `" ~ key ~ "`: "
+			~ str!(Spec[0].Type) ~ " and " ~ str!Type);
+
+		static if (op != TagOp.set)
+			alias TagSpecSeq = Tail;
+		else static if (Spec.length == 0)
+			alias TagSpecSeq = AliasSeq!(TagSpec!(Type, key, [ index ]), Tail);
+		else static if (Spec.length == 1)
+			alias TagSpecSeq = MergeTagSpecs!(TagSpec!(Type, key, [ index ] ~ Spec[0].setters), Tail);
+		else
+			static assert(0, "bug");
+	}
+}
+
+unittest {
+	alias stageTags = AliasSeq!(
+		TagAttributeTuple!(3, tagSetter!(uint, "foo")),
+		TagAttributeTuple!(4, tagSetter!(string, "bar")),
+		TagAttributeTuple!(5, tagGetter!(uint, "foo"), tagSetter!(uint, "foo")),
+		TagAttributeTuple!(6, tagGetter!(uint, "foo", string, "bar")));
+	alias specs = TagSpecSeq!stageTags;
+	static assert(specs.length == 2);
+	static assert(is(Id!specs == Id!(
+		TagSpec!(uint, "foo", [ 3, 5 ]),
+		TagSpec!(string, "bar", [ 4 ]))));
+}
+
+/// Structure that holds values of a single tag for all subranges of a pipeline.
+private struct Tag(alias Spec) {
+	alias T = Spec.Type;
+	enum size_t length = Spec.setters.length;
 	T[length] store;
 
 	template storeIndex(size_t stageIndex, size_t left = 0, size_t right = length) {
@@ -53,7 +202,7 @@ private struct Tag(T, string key, size_t[] setters)
 			enum storeIndex = left;
 		} else {
 			enum size_t m = (left + right) / 2;
-			static if (stageIndex < setters[m])
+			static if (stageIndex < Spec.setters[m])
 				enum storeIndex = storeIndex!(stageIndex, left, m);
 			else
 				enum storeIndex = storeIndex!(stageIndex, m, right);
@@ -63,14 +212,14 @@ private struct Tag(T, string key, size_t[] setters)
 	void set(size_t index)(T value)
 	{
 		enum si = storeIndex!index;
-		static assert(setters[si] == index);
+		static assert(Spec.setters[si] == index);
 		store[si] = value;
 	}
 
 	T get(size_t index)()
 	{
 		import std.conv : to;
-		static assert(index > setters[0], "There is no setter for tag " ~ name
+		static assert(index > Spec.setters[0], "There is no setter for tag " ~ name
 			~ " before stage #" ~ index.to!string);
 		enum si = storeIndex!(index - 1);
 		return store[si];
@@ -78,7 +227,7 @@ private struct Tag(T, string key, size_t[] setters)
 }
 
 unittest {
-	Tag!(string, "sometag", [ 7, 13, 19, 32 ]) tag;
+	Tag!(TagSpec!(string, "sometag", [ 7, 13, 19, 32 ])) tag;
 	tag.set!7("foo");
 	tag.set!13("bar");
 	tag.set!19("baz");
@@ -97,7 +246,93 @@ unittest {
 	assert(tag.get!33 == "quux");
 }
 
-struct NullMetadata {
-	enum bool isGetter(alias S) = false;
-	enum bool isSetter(alias S) = false;
+private string escape(string s)
+{
+	assert(__ctfe);
+	import std.array : appender;
+	import std.format : formattedWrite;
+	import std.ascii : isAlpha, isAlphaNum;
+	auto app = appender!string();
+	app.put("_");
+	if (s.length == 0)
+		return app.data;
+	if (s[0].isAlpha)
+		app.put(s[0]);
+	else
+		app.formattedWrite("_%02X", s[0]);
+	for (;;) {
+		s = s[1 .. $];
+		if (s.length == 0)
+			break;
+		if (s[0].isAlphaNum)
+			app.put(s[0]);
+		else
+			app.formattedWrite("_%02X", s[0]);
+	}
+	return app.data;
+}
+
+unittest {
+	static assert("".escape == "_");
+	static assert("bar".escape == "_bar");
+	static assert("5foo".escape == "__35foo");
+	static assert("_foo.bar".escape == "__5Ffoo_2Ebar");
+}
+
+/// Structure that holds values of all tags for all subranges in a pipeline.
+private struct TagTuple(tagSpecs...)
+	if (allSatisfy!(isTagSpec, tagSpecs))
+{
+	alias specMap(alias spec) = AliasSeq!(Tag!spec, spec.key.escape);
+	alias Tup = Tuple!(staticMap!(specMap, tagSpecs));
+	Tup tags;
+
+	alias ValueType(string key) = TagSpecByKey!(key, tagSpecs)[0].Type;
+
+	ValueType!k get(string k, size_t i)()
+	{
+		import std.conv : to;
+		mixin("return tags." ~ k.escape ~ ".get!(" ~ i.to!string ~ ");");
+	}
+
+	void set(string k, size_t i)(ValueType!k value)
+	{
+		import std.conv : to;
+		mixin("tags." ~ k.escape ~ ".set!(" ~ i.to!string ~ ")(value);");
+	}
+}
+
+unittest {
+	alias specs = AliasSeq!(TagSpec!(uint, "foo.bar", [ 3, 5, 17 ]), TagSpec!(string, "bar.baz", [ 4, 5, 13 ]));
+	alias T = TagTuple!specs;
+	static assert(is(T.ValueType!"foo.bar" == uint));
+	static assert(is(T.ValueType!"bar.baz" == string));
+	T tup;
+	tup.set!("foo.bar", 3)(42);
+	assert(tup.get!("foo.bar", 4) == 42);
+}
+
+template hasOp(TagOp op) {
+	enum hasOp(alias Attr) = Attr.op == op;
+}
+
+///
+package struct Metadata(TagAttributeTuples...) {
+private:
+	template test(size_t i, TagOp op) {
+		enum test(alias S) = S.index == i && anySatisfy!(hasOp!op, S.tagAttributes);
+	}
+
+	enum bool isGetter(size_t index) = anySatisfy!(test!(index, TagOp.get), TagAttributeTuples);
+	enum bool isSetter(size_t index) = anySatisfy!(test!(index, TagOp.set), TagAttributeTuples);
+
+	alias Tup = TagTuple!(TagSpecSeq!TagAttributeTuples);
+	Tup tup;
+
+public:
+	///
+	alias ValueType(string key) = Tup.ValueType!key;
+
+	void set(string key, size_t index)(ValueType!key value) { tup.set!(key, index)(value); }
+	ValueType!key get(string key, size_t index)() { return tup.get!(key, index); }
 }

--- a/source/flod/metadata.d
+++ b/source/flod/metadata.d
@@ -1,0 +1,98 @@
+/** Pass metadata alongside the data stream.
+ *
+ *  Authors: $(LINK2 https://github.com/epi, Adrian Matoga)
+ *  Copyright: © 2016 Adrian Matoga
+ *  License: $(LINK2 http://www.boost.org/users/license.html, BSL-1.0).
+ */
+module flod.metadata;
+
+import std.algorithm : isSorted;
+import std.meta : Filter;
+import std.typecons : tuple;
+
+import flod.traits;
+
+package enum TagOp { get, set }
+
+package struct TagSpec(T, string k, TagOp o) {
+	alias Type = T;
+	enum string key = k;
+	enum TagOp op = o;
+}
+
+enum tagSetter() = tuple().expand;
+enum tagGetter() = tuple().expand;
+enum tagSetter(T, string k, Z...) = tuple(TagSpec!(T, k, TagOp.set)(), tagSetter!Z).expand;
+enum tagGetter(T, string k, Z...) = tuple(TagSpec!(T, k, TagOp.get)(), tagGetter!Z).expand;
+
+private enum isTagSpec(S...) = is(typeof(S[0]) : TagSpec!_a, _a...);
+package enum getTagSpecs(alias S) = Filter!(isTagSpec, __traits(getAttributes, S));
+
+unittest {
+	@tagSetter!(uint, "foo")
+	@tagSetter!(string, "bar")
+	@tagGetter!(double, "baz", string, "quux")
+	@pushSink!uint
+	static struct Foo {}
+	enum x = getTagSpecs!Foo;
+	static assert(x.length == 4);
+	static assert(x[0] == TagSpec!(uint, "foo", TagOp.set)());
+	static assert(x[1] == TagSpec!(string, "bar", TagOp.set)());
+	static assert(x[2] == TagSpec!(double, "baz", TagOp.get)());
+	static assert(x[3] == TagSpec!(string, "quux", TagOp.get)());
+}
+
+private struct Tag(T, string key, size_t[] setters)
+	if (isSorted(setters))
+{
+	enum size_t length = setters.length;
+	T[length] store;
+
+	template storeIndex(size_t stageIndex, size_t left = 0, size_t right = length) {
+		static if (right - left == 1) {
+			enum storeIndex = left;
+		} else {
+			enum size_t m = (left + right) / 2;
+			static if (stageIndex < setters[m])
+				enum storeIndex = storeIndex!(stageIndex, left, m);
+			else
+				enum storeIndex = storeIndex!(stageIndex, m, right);
+		}
+	}
+
+	void set(size_t index)(T value)
+	{
+		enum si = storeIndex!index;
+		static assert(setters[si] == index);
+		store[si] = value;
+	}
+
+	T get(size_t index)()
+	{
+		import std.conv : to;
+		static assert(index > setters[0], "There is no setter for tag " ~ name
+			~ " before stage #" ~ index.to!string);
+		enum si = storeIndex!(index - 1);
+		return store[si];
+	}
+}
+
+unittest {
+	Tag!(string, "sometag", [ 7, 13, 19, 32 ]) tag;
+	tag.set!7("foo");
+	tag.set!13("bar");
+	tag.set!19("baz");
+	tag.set!32("quux");
+	static assert(!__traits(compiles, tag.set!5("fail")));
+	static assert(!__traits(compiles, tag.set!14("fail")));
+	static assert(!__traits(compiles, tag.get!0));
+	static assert(!__traits(compiles, tag.get!7));
+	assert(tag.get!8 == "foo");
+	assert(tag.get!13 == "foo");
+	assert(tag.get!14 == "bar");
+	assert(tag.get!18 == "bar");
+	assert(tag.get!19 == "bar");
+	assert(tag.get!20 == "baz");
+	assert(tag.get!32 == "baz");
+	assert(tag.get!33 == "quux");
+}

--- a/source/flod/metadata.d
+++ b/source/flod/metadata.d
@@ -96,3 +96,8 @@ unittest {
 	assert(tag.get!32 == "baz");
 	assert(tag.get!33 == "quux");
 }
+
+struct NullMetadata {
+	enum bool isGetter(alias S) = false;
+	enum bool isSetter(alias S) = false;
+}

--- a/source/flod/pipeline.d
+++ b/source/flod/pipeline.d
@@ -72,8 +72,9 @@ version(unittest) {
 	}
 
 	@pullSource!ulong
-	struct TestPullSource {
+	struct TestPullSource(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 
 		size_t pull(ulong[] buf)
 		{
@@ -85,8 +86,9 @@ version(unittest) {
 	}
 
 	@peekSource!ulong
-	struct TestPeekSource {
+	struct TestPeekSource(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 
 		const(ulong)[] peek(size_t n)
 		{
@@ -98,9 +100,9 @@ version(unittest) {
 	}
 
 	@pushSource!ulong
-	struct TestPushSource(Sink) {
+	struct TestPushSource(alias Context, A...) {
 		mixin TestStage;
-		Sink sink;
+		mixin Context!A;
 
 		void run()()
 		{
@@ -114,9 +116,9 @@ version(unittest) {
 	}
 
 	@allocSource!ulong
-	struct TestAllocSource(Sink) {
+	struct TestAllocSource(alias Context, A...) {
 		mixin TestStage;
-		Sink sink;
+		mixin Context!A;
 
 		void run()()
 		{
@@ -136,9 +138,9 @@ version(unittest) {
 	// sinks:
 
 	@pullSink!ulong
-	struct TestPullSink(Source) {
+	struct TestPullSink(alias Context, A...) {
 		mixin TestStage;
-		Source source;
+		mixin Context!A;
 
 		void run()
 		{
@@ -153,9 +155,9 @@ version(unittest) {
 	}
 
 	@peekSink!ulong
-	struct TestPeekSink(Source) {
+	struct TestPeekSink(alias Context, A...) {
 		mixin TestStage;
-		Source source;
+		mixin Context!A;
 
 		void run()
 		{
@@ -173,8 +175,9 @@ version(unittest) {
 	}
 
 	@pushSink!ulong
-	struct TestPushSink {
+	struct TestPushSink(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 
 		size_t push(const(ulong)[] buf)
 		{
@@ -188,8 +191,9 @@ version(unittest) {
 	}
 
 	@allocSink!ulong
-	struct TestAllocSink {
+	struct TestAllocSink(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 		ulong[] last;
 
 		bool alloc(ref ulong[] buf, size_t n)
@@ -220,9 +224,10 @@ version(unittest) {
 	// filter
 
 	@peekSink!ulong @peekSource!ulong
-	struct TestPeekFilter(Source) {
+	struct TestPeekFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
+		mixin Context!A;
+
 		const(ulong)[] peek(size_t n)
 		{
 			return source.peek(n).map!(filter!"peek").array();
@@ -231,9 +236,10 @@ version(unittest) {
 	}
 
 	@peekSink!ulong @pullSource!ulong
-	struct TestPeekPullFilter(Source) {
+	struct TestPeekPullFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
+		mixin Context!A;
+
 		size_t pull(ulong[] buf)
 		{
 			auto ib = source.peek(buf.length);
@@ -245,10 +251,10 @@ version(unittest) {
 	}
 
 	@peekSink!ulong @pushSource!ulong
-	struct TestPeekPushFilter(Source, Sink) {
+	struct TestPeekPushFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
-		Sink sink;
+		mixin Context!A;
+
 		void run()()
 		{
 			for (;;) {
@@ -262,10 +268,10 @@ version(unittest) {
 	}
 
 	@peekSink!ulong @allocSource!ulong
-	struct TestPeekAllocFilter(Source, Sink) {
+	struct TestPeekAllocFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
-		Sink sink;
+		mixin Context!A;
+
 		void run()()
 		{
 			ulong[] buf;
@@ -283,9 +289,10 @@ version(unittest) {
 	}
 
 	@pullSink!ulong @pullSource!ulong
-	struct TestPullFilter(Source) {
+	struct TestPullFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
+		mixin Context!A;
+
 		size_t pull(ulong[] buf)
 		{
 			size_t n = source.pull(buf);
@@ -296,9 +303,10 @@ version(unittest) {
 	}
 
 	@pullSink!ulong @peekSource!ulong
-	struct TestPullPeekFilter(Source) {
+	struct TestPullPeekFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
+		mixin Context!A;
+
 		const(ulong)[] peek(size_t n)
 		{
 			auto buf = new ulong[n];
@@ -311,10 +319,10 @@ version(unittest) {
 	}
 
 	@pullSink!ulong @pushSource!ulong
-	struct TestPullPushFilter(Source, Sink) {
+	struct TestPullPushFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
-		Sink sink;
+		mixin Context!A;
+
 		void run()()
 		{
 			for (;;) {
@@ -329,10 +337,10 @@ version(unittest) {
 	}
 
 	@pullSink!ulong @allocSource!ulong
-	struct TestPullAllocFilter(Source, Sink) {
+	struct TestPullAllocFilter(alias Context, A...) {
 		mixin TestStage;
-		Source source;
-		Sink sink;
+		mixin Context!A;
+
 		void run()()
 		{
 			for (;;) {
@@ -349,9 +357,10 @@ version(unittest) {
 	}
 
 	@pushSink!ulong @pushSource!ulong
-	struct TestPushFilter(Sink) {
+	struct TestPushFilter(alias Context, A...) {
 		mixin TestStage;
-		Sink sink;
+		mixin Context!A;
+
 		size_t push(const(ulong)[] buf)
 		{
 			return sink.push(buf.map!(filter!"push").array());
@@ -359,9 +368,10 @@ version(unittest) {
 	}
 
 	@pushSink!ulong @allocSource!ulong
-	struct TestPushAllocFilter(Sink) {
+	struct TestPushAllocFilter(alias Context, A...) {
 		mixin TestStage;
-		Sink sink;
+		mixin Context!A;
+
 		size_t push(const(ulong)[] buf)
 		out(result) { assert(result <= buf.length); }
 		body
@@ -376,9 +386,9 @@ version(unittest) {
 	}
 
 	@pushSink!ulong @pullSource!ulong
-	struct TestPushPullFilter(alias Scheduler) {
-		mixin Scheduler;
+	struct TestPushPullFilter(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 		ulong[] buffer;
 
 		size_t push(const(ulong)[] buf)
@@ -404,9 +414,9 @@ version(unittest) {
 	}
 
 	@pushSink!ulong @peekSource!ulong
-	struct TestPushPeekFilter(alias Scheduler) {
-		mixin Scheduler;
+	struct TestPushPeekFilter(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 		ulong[] buffer;
 
 		size_t push(const(ulong)[] buf)
@@ -433,9 +443,9 @@ version(unittest) {
 	}
 
 	@allocSink!ulong @allocSource!ulong
-	struct TestAllocFilter(Sink) {
+	struct TestAllocFilter(alias Context, A...) {
 		mixin TestStage;
-		Sink sink;
+		mixin Context!A;
 		ulong[] buf;
 
 		bool alloc(ref ulong[] buf, size_t n)
@@ -454,9 +464,9 @@ version(unittest) {
 	}
 
 	@allocSink!ulong @pushSource!ulong
-	struct TestAllocPushFilter(Sink) {
+	struct TestAllocPushFilter(alias Context, A...) {
 		mixin TestStage;
-		Sink sink;
+		mixin Context!A;
 		ulong[] buffer;
 
 		bool alloc(ref ulong[] buf, size_t n)
@@ -474,9 +484,9 @@ version(unittest) {
 	}
 
 	@allocSink!ulong @pullSource!ulong
-	struct TestAllocPullFilter(alias Scheduler) {
-		mixin Scheduler;
+	struct TestAllocPullFilter(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 		ulong[] buffer;
 		size_t readOffset;
 		size_t writeOffset;
@@ -513,9 +523,9 @@ version(unittest) {
 	}
 
 	@allocSink!ulong @peekSource!ulong
-	struct TestAllocPeekFilter(alias Scheduler) {
-		mixin Scheduler;
+	struct TestAllocPeekFilter(alias Context, A...) {
 		mixin TestStage;
+		mixin Context!A;
 		ulong[] buffer;
 		size_t readOffset;
 		size_t writeOffset;
@@ -658,18 +668,29 @@ struct SinkDrivenFiberScheduler {
 	}
 }
 
-mixin template FiberScheduler() {
+mixin template Context(alias _Stage, _Src = typeof(null), _Snk = typeof(null)) {
 	import flod.pipeline;
-	SinkDrivenFiberScheduler _flod_scheduler;
-
-	int yield() { return _flod_scheduler.yield(); }
-	void spawn(void delegate() dg)
-	{
-		import core.thread : Fiber;
-		if (!_flod_scheduler.fiber)
-			_flod_scheduler.fiber = new Fiber(dg, 65536);
+	alias Stage = _Stage;
+	static if (!is(_flod_Src == typeof(null))) {
+		alias Source = _Src;
+		Source source;
 	}
-	void stop() { _flod_scheduler.stop(); }
+	static if (!is(_flod_Snk == typeof(null))) {
+		alias Sink = _Snk;
+		Sink sink;
+	}
+	static if (isPassiveSink!Stage && isPassiveSource!Stage) {
+		SinkDrivenFiberScheduler _flod_scheduler;
+
+		int yield()() { return _flod_scheduler.yield(); }
+		void spawn()(void delegate() dg)
+		{
+			import core.thread : Fiber;
+			if (!_flod_scheduler.fiber)
+				_flod_scheduler.fiber = new Fiber(dg, 65536);
+		}
+		void stop()() { _flod_scheduler.stop(); }
+	}
 }
 
 // forwards all calls to its impl
@@ -713,36 +734,40 @@ private struct Forward(S, Flag!"readFromSink" readFromSink = No.readFromSink) {
 	auto push(T)(const(T)[] buf) { return _impl.push(buf); }
 }
 
-private template Inverter(alias method, T) {
-	@method
-	struct Inverter(Source) {
-		import core.thread : Fiber;
+private template Inverter(alias Stage) {
+	alias E = Traits!Stage.SinkElementType;
+	static if (isPullSource!Stage) {
+		@pullSource!E
+		struct Inverter(alias Context, alias St, So = typeof(null), Si = typeof(null)) {
+			mixin Context!(St, So, Si);
 
-		Source source;
+			~this() { source.sink.stop(); }
 
-		~this()
-		{
-			source.sink.stop();
+			void run() { source.run(); }
+
+			size_t pull()(E[] buf)
+			{
+				source.sink.spawn(&run);
+				return source.sink.pull(buf);
+			}
 		}
+	} else static if (isPeekSource!Stage) {
+		@peekSource!E
+		struct Inverter(alias Context, alias St, So = typeof(null), Si = typeof(null)) {
+			mixin Context!(St, So, Si);
 
-		void run()
-		{
-			source.run();
+			~this() { source.sink.stop(); }
+
+			void run() { source.run(); }
+
+			const(E)[] peek()(size_t n)
+			{
+				source.sink.spawn(&run);
+				return source.sink.peek(n);
+			}
+
+			void consume()(size_t n) { source.sink.consume(n); }
 		}
-
-		size_t pull()(T[] buf)
-		{
-			source.sink.spawn(&run);
-			return source.sink.pull(buf);
-		}
-
-		const(T)[] peek()(size_t n)
-		{
-			source.sink.spawn(&run);
-			return source.sink.peek(n);
-		}
-
-		void consume()(size_t n) { source.sink.consume(n); }
 	}
 }
 
@@ -773,7 +798,7 @@ private struct Pipeline(alias S, SoP, SiP, A...) {
 		alias FirstStage = SourcePipeline.FirstStage;
 		enum sourcePipeStr = SourcePipeline.pipeStr ~ "->";
 		enum sourceTreeStr(int indent) = SourcePipeline.treeStr!(indent + 1) ~ "\n";
-		enum sourceStr = SourcePipeline.str ~ ".";
+		enum sourceStr = SourcePipeline.str ~ "->";
 	} else {
 		alias FirstStage = Stage;
 		enum sourcePipeStr = "";
@@ -785,7 +810,7 @@ private struct Pipeline(alias S, SoP, SiP, A...) {
 		alias LastStage = SinkPipeline.LastStage;
 		enum sinkPipeStr = "->" ~ SinkPipeline.pipeStr;
 		enum sinkTreeStr(int indent) = "\n" ~ SinkPipeline.treeStr!(indent + 1);
-		enum sinkStr = "." ~ SinkPipeline.str;
+		enum sinkStr = "->" ~ SinkPipeline.str;
 	} else {
 		alias LastStage = Stage;
 		enum sinkPipeStr = "";
@@ -807,18 +832,17 @@ private struct Pipeline(alias S, SoP, SiP, A...) {
 	static if (hasSource && is(SourcePipeline.Type U))
 		alias SourceType = U;
 
+	import flod.meta : isType;
 	static if (isActiveSource!Stage && isActiveSink!Stage && is(SinkType) && is(SourceType))
-		alias Type = Forward!(Stage!(SourceType, SinkType));
+		alias Type = Forward!(Stage!(Context, Stage, SourceType, SinkType));
 	else static if (isActiveSource!Stage && !isActiveSink!Stage && is(SinkType))
-		alias Type = Forward!(Stage!SinkType, Yes.readFromSink);
+		alias Type = Forward!(Stage!(Context, Stage, typeof(null), SinkType), Yes.readFromSink);
 	else static if (!isActiveSource!Stage && isActiveSink!Stage && is(SourceType))
-		alias Type = Forward!(Stage!SourceType);
-	else static if (isPassiveSink!Stage && isPassiveSource!Stage && is(Stage!FiberScheduler SF))
-		alias Type = Forward!SF;
-	else static if (is(Stage))
-		alias Type = Forward!Stage;
-	else static if (isPassiveSource!Stage && !isSink!Stage && is(SourceType)) // inverter
-		alias Type = Forward!(Stage!SourceType);
+		alias Type = Forward!(Stage!(Context, Stage, SourceType));
+	else static if (isPassiveSource!Stage && !isSink!Stage && is(SourceType)) // && isType!(Stage, Context, Stage, SourceType)) // inverter
+		alias Type = Forward!(Stage!(Context, Stage, SourceType));
+	else static if (isType!(Stage, Context, Stage))
+		alias Type = Forward!(Stage!(Context, Stage));
 
 	SourcePipeline sourcePipeline;
 	SinkPipeline sinkPipeline;
@@ -847,11 +871,11 @@ private struct Pipeline(alias S, SoP, SiP, A...) {
 						}
 					} else {
 						static if (hasSink) {
-							auto result = pipeline!(Inverter!(sourceMethod!NextStage, SourceE))(
+							auto result = pipeline!(Inverter!NextStage)(
 								pipeline!Stage(sourcePipeline, sinkPipeline.pipe!NextStage(nextArgs), args),
 								null);
 						} else {
-							auto result = pipeline!(Inverter!(sourceMethod!NextStage, SourceE))(
+							auto result = pipeline!(Inverter!NextStage)(
 								pipeline!Stage(sourcePipeline, pipeline!NextStage(null, null, nextArgs), args),
 								null);
 						}
@@ -884,25 +908,26 @@ private struct Pipeline(alias S, SoP, SiP, A...) {
 				sinkPipeline.construct(t.sink);
 			constructInPlace(t, args);
 		}
-	}
 
-	static if (!isSink!FirstStage && !isSource!LastStage) {
-		void run()()
-		{
-			Type t;
-			construct(t);
-			t.run();
+		static if (!isSink!FirstStage && !isSource!LastStage) {
+			void run()()
+			{
+				Type t;
+				construct(t);
+				t.run();
+			}
+		}
+
+		static if (!isSink!FirstStage && !isActiveSource!LastStage) {
+			auto create()()
+			{
+				Type t;
+				construct(t);
+				return t;
+			}
 		}
 	}
 
-	static if (!isSink!FirstStage && !isActiveSource!LastStage) {
-		auto create()()
-		{
-			Type t;
-			construct(t);
-			return t;
-		}
-	}
 }
 
 private auto pipeline(alias Stage, SoP, SiP, A...)(auto ref SoP sourcePipeline, auto ref SiP sinkPipeline, auto ref A args)

--- a/source/flod/traits.d
+++ b/source/flod/traits.d
@@ -164,6 +164,7 @@ enum isPassiveSink(alias S) = isPushSink!S || isAllocSink!S;
 enum isActiveSink(alias S) = isPeekSink!S || isPullSink!S;
 enum isSink(alias S) = isPassiveSink!S || isActiveSink!S;
 
+enum isStage(alias S) = isSource!S || isSink!S;
 
 /** Returns `true` if `S[0]` is a source and `S[1]` is a sink and they both use the same
  *  method of passing data.


### PR DESCRIPTION
Introduces metadata support, as well other changes that may seem unrelated but were necessary:
- Unified stage interface:

``` d
@attributes...
struct Stage(alias Context, A...) {
    mixin Context!A;
}
```
- Pipeline instance struct is now a flat structure with all stages stored as a tuple, where any stage can access the containing pipeline instance struct, and from there – any other stage.
